### PR TITLE
Added: 'Sync' to handles explicitly to ensure platform consistency.

### DIFF
--- a/src/handles/readonly/unix.rs
+++ b/src/handles/readonly/unix.rs
@@ -9,6 +9,7 @@ pub struct InnerHandle {
     _marker: PhantomData<()>,
 }
 
+unsafe impl Sync for InnerHandle {}
 unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {

--- a/src/handles/readonly/windows.rs
+++ b/src/handles/readonly/windows.rs
@@ -17,6 +17,7 @@ pub struct InnerHandle {
     _marker: PhantomData<()>,
 }
 
+unsafe impl Sync for InnerHandle {}
 unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {

--- a/src/handles/readwrite/unix.rs
+++ b/src/handles/readwrite/unix.rs
@@ -9,6 +9,7 @@ pub struct InnerHandle {
     _marker: PhantomData<()>,
 }
 
+unsafe impl Sync for InnerHandle {}
 unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {

--- a/src/handles/readwrite/windows.rs
+++ b/src/handles/readwrite/windows.rs
@@ -17,6 +17,7 @@ pub struct InnerHandle {
     _marker: PhantomData<()>,
 }
 
+unsafe impl Sync for InnerHandle {}
 unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {


### PR DESCRIPTION
This explicitly adds 'Sync' to handles.
It fixes a discrepancy between Unix having Sync but Windows not having Sync.