### PR TITLE
Added: 'Path' support for 'std'

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,20 +21,20 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
-          
-          # Linux Targets (Ubuntu) - no_std features  
+
+          # Linux Targets (Ubuntu) - no_std features
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap no-format" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap no-format trim-file-lengths" }
-          
+
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
-          
+
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-pgo: false, use-cross: true, features: "std mmap" }
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-pgo: false, use-cross: true, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-pgo: false, use-cross: true, features: "std mmap no-format trim-file-lengths" }
-          
+
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-pgo: false, use-cross: true, features: "std mmap" }
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-pgo: false, use-cross: true, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-pgo: false, use-cross: true, features: "std mmap no-format trim-file-lengths" }
@@ -43,11 +43,11 @@ jobs:
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
-          
+
           # Windows Targets - no_std features
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "mmap" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "mmap no-format" }
-          
+
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
@@ -57,10 +57,10 @@ jobs:
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
-          
+
           # macOS Targets - no_std features
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "mmap" }
-          
+
           - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
@@ -69,7 +69,7 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-linux-android, use-pgo: false, use-cross: true, features: "std mmap" }
           - { os: ubuntu-latest, target: x86_64-linux-android, use-pgo: false, use-cross: true, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: x86_64-linux-android, use-pgo: false, use-cross: true, features: "std mmap no-format trim-file-lengths" }
-          
+
           - { os: ubuntu-latest, target: i686-linux-android, use-pgo: false, use-cross: true, features: "std mmap" }
           - { os: ubuntu-latest, target: i686-linux-android, use-pgo: false, use-cross: true, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: i686-linux-android, use-pgo: false, use-cross: true, features: "std mmap no-format trim-file-lengths" }
@@ -129,7 +129,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - name: Publish Rust Crate and Artifacts  
+      - name: Publish Rust Crate and Artifacts
         uses: Reloaded-Project/devops-publish-action@v1
         with:
           crates-io-token: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,15 @@ jobs:
     strategy:
       matrix:
         include:
-          # Linux Targets (Ubuntu)
+          # Linux Targets (Ubuntu) - std features
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
+          
+          # Linux Targets (Ubuntu) - no_std features  
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap no-format" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "mmap no-format trim-file-lengths" }
           
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-pgo: true, use-cross: false, features: "std mmap no-format" }
@@ -34,20 +39,27 @@ jobs:
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-pgo: false, use-cross: true, features: "std mmap no-format" }
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-pgo: false, use-cross: true, features: "std mmap no-format trim-file-lengths" }
 
-          # Windows Targets
+          # Windows Targets - std features
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
+          
+          # Windows Targets - no_std features
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "mmap" }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-pgo: true, use-cross: false, features: "mmap no-format" }
           
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
           # aarch64 is disabled; because there is no native runner
 
-          # macOS Targets
+          # macOS Targets - std features
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
           - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
+          
+          # macOS Targets - no_std features
+          - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "mmap" }
           
           - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
           - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
@@ -67,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Libraries and Run Tests
+      - name: Run Tests and Coverage
         uses: Reloaded-Project/devops-rust-test-and-coverage@v1
         with:
           upload-coverage: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "rust-analyzer.checkOnSave.command": "clippy",
     "[rust]": {
         "editor.formatOnSave": true
     },
     "coverage-gutters.coverageFileNames": [
         "cobertura.xml"
-    ]
+    ],
+    "rust-analyzer.check.command": "clippy"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,17 +25,17 @@ no-format = [ "dep:itoa", "dep:nanokit" ]
 trim-file-lengths = []
 
 [dependencies]
-thiserror = "2.0.9"
-bitflags = "2.6.0"
-itoa = { version = "1.0.14", default-features = false, optional = true }
+thiserror = "2.0.12"
+bitflags = "2.9.1"
+itoa = { version = "1.0.15", default-features = false, optional = true }
 nanokit = { version = "0.2.0", features = ["no-inline-concat"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.169"
-errno = "0.3.10"
+libc = "0.2.174"
+errno = "0.3.13"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.59.0"
+version = "0.60.2"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
@@ -48,7 +48,7 @@ features = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
-tempfile = "3.14.0"
+tempfile = "3.20.0"
 
 # Profile Build
 [profile.profile]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightweight-mmap"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Simple memory mapping helpers for Rust, with minimal amount of code generated."
 repository = "https://github.com/Sewer56/lightweight-mmap"

--- a/README.MD
+++ b/README.MD
@@ -93,19 +93,23 @@ For other platforms, level of support is unknown.
 ### File Handles
 
 Open a read-only file handle to an existing file:
-```rust,ignore
-let handle = ReadOnlyFileHandle::open("assets/test_file.txt").unwrap();
+```rust
+use lightweight_mmap::ReadOnlyFileHandle;
+let handle = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
 ```
 
 Open a read-write file handle to an existing file:
-```rust,ignore
-let handle = ReadWriteFileHandle::open("assets/test_file.txt").unwrap();
+```rust
+use lightweight_mmap::ReadWriteFileHandle;
+let handle = ReadWriteFileHandle::open("Cargo.toml").unwrap();
 ```
 
 Create a new file with pre-allocated size:
 
-```rust,ignore
-let handle = ReadWriteFileHandle::create_preallocated("assets/test_file.txt", 1024).unwrap();
+```rust
+use lightweight_mmap::ReadWriteFileHandle;
+let handle = ReadWriteFileHandle::create_preallocated("test_file.txt", 1024).unwrap();
+# std::fs::remove_file("test_file.txt").ok();
 ```
 
 This will create a new file or overwrite an existing file.
@@ -113,35 +117,41 @@ This will create a new file or overwrite an existing file.
 ### Memory Mapping
 
 Create a read-only memory mapping:
-```rust,ignore
+```rust
+# #[cfg(feature = "mmap")]
+# {
 use lightweight_mmap::{ReadOnlyFileHandle, ReadOnlyMmap};
 
 // Open the file
-let handle = ReadOnlyFileHandle::open("data.bin").unwrap();
+let handle = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
 
-// Map 1024 bytes starting at offset 4096
-let mapping = ReadOnlyMmap::new(&handle, 4096, 1024).unwrap();
+// Map 1024 bytes starting at offset 0
+let mapping = ReadOnlyMmap::new(&handle, 0, 1024).unwrap();
 
 // Access the mapped memory
 let data = mapping.as_slice();
+# }
 ```
 
 Create a read-write memory mapping:
 
-```rust,ignore
+```rust
+# #[cfg(feature = "mmap")]
+# {
 use lightweight_mmap::{ReadWriteFileHandle, ReadWriteMmap};
 
-// Open the file
-let handle = ReadWriteFileHandle::open("data.bin").unwrap();
+// Create a temporary file for writing
+let handle = ReadWriteFileHandle::create_preallocated("temp_write.txt", 1024).unwrap();
 
-// Map 1024 bytes starting at offset 4096
-let mapping = ReadWriteMmap::new(&handle, 4096, 1024).unwrap();
+// Map 1024 bytes starting at offset 0
+let mut mapping = ReadWriteMmap::new(&handle, 0, 1024).unwrap();
 
 // Access and modify the mapped memory
-unsafe {
-    let data = core::slice::from_raw_parts_mut(mapping.data(), mapping.len());
-    data[0] = 42;
-}
+let data = mapping.as_mut_slice();
+data[0] = 42;
+
+# std::fs::remove_file("temp_write.txt").ok();
+# }
 ```
 
 Note: Memory mappings cannot outlive their file handles (compiler should ensure this), and the mapped
@@ -152,14 +162,27 @@ memory should be accessed carefully to avoid data races.
 The default implementation of `Mmap` cannot be shared across threads, the lifetime
 is tied to the current stack. If you need to share across threads, use the `Owned` variants.
 
-```rust,ignore
-let handle = Arc::new(ReadOnlyFileHandle::open("data.bin").unwrap());
+```rust
+# #[cfg(feature = "mmap")]
+# {
+use lightweight_mmap::{ReadOnlyFileHandle, OwnedReadOnlyMmap};
+use std::sync::Arc;
+
+let handle = Arc::new(ReadOnlyFileHandle::open("Cargo.toml").unwrap());
 let mapping = unsafe { OwnedReadOnlyMmap::new(handle, 0, 1024).unwrap() };
+# }
 ```
 
-```rust,ignore
-let handle = Arc::new(ReadWriteFileHandle::open("data.bin").unwrap());
+```rust
+# #[cfg(feature = "mmap")]
+# {
+use lightweight_mmap::{ReadWriteFileHandle, OwnedReadWriteMmap};
+use std::sync::Arc;
+
+let handle = Arc::new(ReadWriteFileHandle::create_preallocated("temp_owned.txt", 1024).unwrap());
 let mapping = unsafe { OwnedReadWriteMmap::new(handle, 0, 1024).unwrap() };
+# std::fs::remove_file("temp_owned.txt").ok();
+# }
 ```
 
 The `Owned` variants internally use `Arc` to share the lifetime of the handle across
@@ -169,11 +192,13 @@ instances.
 
 Provide hints to the operating system about how memory mapped regions will be accessed:
 
-```rust,ignore
+```rust
+# #[cfg(feature = "mmap")]
+# {
 use lightweight_mmap::{ReadOnlyFileHandle, ReadOnlyMmap, MemoryAdvice};
 
 // Open and map the file
-let handle = ReadOnlyFileHandle::open("data.bin").unwrap();
+let handle = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
 let mapping = ReadOnlyMmap::new(&handle, 0, 1024).unwrap();
 
 // Indicate we'll access this memory soon
@@ -184,6 +209,7 @@ mapping.advise(MemoryAdvice::SEQUENTIAL);
 
 // Combine multiple hints
 mapping.advise(MemoryAdvice::WILL_NEED | MemoryAdvice::SEQUENTIAL);
+# }
 ```
 
 Available advice flags:

--- a/README.MD
+++ b/README.MD
@@ -93,20 +93,20 @@ For other platforms, level of support is unknown.
 ### File Handles
 
 Open a read-only file handle to an existing file:
-```rust
+```rust,no_run
 use lightweight_mmap::ReadOnlyFileHandle;
 let handle = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
 ```
 
 Open a read-write file handle to an existing file:
-```rust
+```rust,no_run
 use lightweight_mmap::ReadWriteFileHandle;
 let handle = ReadWriteFileHandle::open("Cargo.toml").unwrap();
 ```
 
 Create a new file with pre-allocated size:
 
-```rust
+```rust,no_run
 use lightweight_mmap::ReadWriteFileHandle;
 let handle = ReadWriteFileHandle::create_preallocated("test_file.txt", 1024).unwrap();
 # std::fs::remove_file("test_file.txt").ok();
@@ -117,7 +117,7 @@ This will create a new file or overwrite an existing file.
 ### Memory Mapping
 
 Create a read-only memory mapping:
-```rust
+```rust,no_run
 # #[cfg(feature = "mmap")]
 # {
 use lightweight_mmap::{ReadOnlyFileHandle, ReadOnlyMmap};
@@ -135,7 +135,7 @@ let data = mapping.as_slice();
 
 Create a read-write memory mapping:
 
-```rust
+```rust,no_run
 # #[cfg(feature = "mmap")]
 # {
 use lightweight_mmap::{ReadWriteFileHandle, ReadWriteMmap};
@@ -162,7 +162,7 @@ memory should be accessed carefully to avoid data races.
 The default implementation of `Mmap` cannot be shared across threads, the lifetime
 is tied to the current stack. If you need to share across threads, use the `Owned` variants.
 
-```rust
+```rust,no_run
 # #[cfg(feature = "mmap")]
 # {
 use lightweight_mmap::{ReadOnlyFileHandle, OwnedReadOnlyMmap};
@@ -173,7 +173,7 @@ let mapping = unsafe { OwnedReadOnlyMmap::new(handle, 0, 1024).unwrap() };
 # }
 ```
 
-```rust
+```rust,no_run
 # #[cfg(feature = "mmap")]
 # {
 use lightweight_mmap::{ReadWriteFileHandle, OwnedReadWriteMmap};
@@ -192,7 +192,7 @@ instances.
 
 Provide hints to the operating system about how memory mapped regions will be accessed:
 
-```rust
+```rust,no_run
 # #[cfg(feature = "mmap")]
 # {
 use lightweight_mmap::{ReadOnlyFileHandle, ReadOnlyMmap, MemoryAdvice};
@@ -228,7 +228,7 @@ The API surface changes depending on whether the `std` feature is enabled:
 
 When the `std` feature is enabled, file path parameters accept any type that implements `AsRef<std::path::Path>`:
 
-```rust
+```rust,no_run
 # #[cfg(feature = "std")]
 # {
 use lightweight_mmap::{ReadOnlyFileHandle, ReadWriteFileHandle};
@@ -247,7 +247,7 @@ let handle4 = ReadWriteFileHandle::create_preallocated("temp_test.txt", 1024).un
 
 When the `std` feature is disabled, file path parameters only accept `&str`:
 
-```rust
+```rust,no_run
 # #[cfg(not(feature = "std"))]
 # {
 use lightweight_mmap::ReadOnlyFileHandle;

--- a/README.MD
+++ b/README.MD
@@ -220,6 +220,55 @@ Available advice flags:
 Note: These are hints and may be ignored by the operating system.
 Not all hints are supported on all platforms. On Windows, only `WILL_NEED` has an effect.
 
+## API Differences: `std` vs `no_std`
+
+The API surface changes depending on whether the `std` feature is enabled:
+
+### With `std` feature (default)
+
+When the `std` feature is enabled, file path parameters accept any type that implements `AsRef<std::path::Path>`:
+
+```rust
+# #[cfg(feature = "std")]
+# {
+use lightweight_mmap::{ReadOnlyFileHandle, ReadWriteFileHandle};
+use std::path::Path;
+
+// These all work with std feature enabled:
+let handle1 = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
+let handle2 = ReadOnlyFileHandle::open(Path::new("Cargo.toml")).unwrap();
+let handle3 = ReadWriteFileHandle::open("Cargo.toml").unwrap();
+let handle4 = ReadWriteFileHandle::create_preallocated("temp_test.txt", 1024).unwrap();
+# std::fs::remove_file("temp_test.txt").ok();
+# }
+```
+
+### Without `std` feature (no_std)
+
+When the `std` feature is disabled, file path parameters only accept `&str`:
+
+```rust
+# #[cfg(not(feature = "std"))]
+# {
+use lightweight_mmap::ReadOnlyFileHandle;
+
+// Only string literals and &str work in no_std:
+let handle1 = ReadOnlyFileHandle::open("Cargo.toml").unwrap();
+
+// Path objects are not available in no_std environments
+// Note: File creation via create_preallocated() typically requires std
+# }
+```
+
+**Affected Methods:**
+
+- `ReadOnlyFileHandle::open()`
+- `ReadWriteFileHandle::open()`
+- `ReadWriteFileHandle::create_preallocated()`
+
+This design allows the library to work efficiently in both `std` and `no_std` environments while
+providing the most ergonomic API for each context.
+
 ## Development
 
 For information on how to work with this codebase, see [README-DEV.MD](README-DEV.MD).

--- a/src/handles/error.rs
+++ b/src/handles/error.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::{String, ToString};
 use core::fmt::*;
 
 /// Represents errors that can occur when providing file data.

--- a/src/handles/readonly/mod.rs
+++ b/src/handles/readonly/mod.rs
@@ -37,6 +37,22 @@ impl ReadOnlyFileHandle {
     /// # Errors
     ///
     /// Returns a `HandleOpenError` if the file cannot be opened.
+    #[cfg(feature = "std")]
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self, HandleOpenError> {
+        let inner = InnerHandle::open(path.as_ref())?;
+        Ok(ReadOnlyFileHandle { inner })
+    }
+
+    /// Opens a file in read-only mode with shared access.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the file to open.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `HandleOpenError` if the file cannot be opened.
+    #[cfg(not(feature = "std"))]
     pub fn open(path: &str) -> Result<Self, HandleOpenError> {
         let inner = InnerHandle::open(path)?;
         Ok(ReadOnlyFileHandle { inner })
@@ -70,7 +86,7 @@ impl ReadOnlyFileHandle {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use std::{fs::OpenOptions, io::Write};
 

--- a/src/handles/readonly/unix.rs
+++ b/src/handles/readonly/unix.rs
@@ -20,6 +20,25 @@ impl InnerHandle {
     /// # Errors
     ///
     /// Returns a [`HandleOpenError`] if the file cannot be opened.
+    #[cfg(feature = "std")]
+    pub fn open(path: &std::path::Path) -> Result<Self, HandleOpenError> {
+        let path_str = path.to_str().ok_or_else(|| {
+            HandleOpenError::failed_to_open_file_handle_unix(-1, "<invalid_utf8>")
+        })?;
+        let fd = open_with_flags(path_str, O_RDONLY)?;
+        Ok(InnerHandle { fd })
+    }
+
+    /// Opens the file with read-only access.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the file to open.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`HandleOpenError`] if the file cannot be opened.
+    #[cfg(not(feature = "std"))]
     pub fn open(path: &str) -> Result<Self, HandleOpenError> {
         let fd = open_with_flags(path, O_RDONLY)?;
         Ok(InnerHandle { fd })

--- a/src/handles/readonly/windows.rs
+++ b/src/handles/readonly/windows.rs
@@ -20,6 +20,18 @@ unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {
     /// Opens the file with appropriate access.
+    #[cfg(feature = "std")]
+    pub fn open(path: &std::path::Path) -> Result<Self, HandleOpenError> {
+        let handle = open_with_access(path, GENERIC_READ, OPEN_EXISTING)?;
+        Ok(InnerHandle {
+            handle,
+            #[cfg(feature = "mmap")]
+            mapping: UnsafeCell::new(INVALID_HANDLE_VALUE),
+        })
+    }
+
+    /// Opens the file with appropriate access.
+    #[cfg(not(feature = "std"))]
     pub fn open(path: &str) -> Result<Self, HandleOpenError> {
         let handle = open_with_access(path, GENERIC_READ, OPEN_EXISTING)?;
         Ok(InnerHandle {

--- a/src/handles/readwrite/mod.rs
+++ b/src/handles/readwrite/mod.rs
@@ -37,6 +37,22 @@ impl ReadWriteFileHandle {
     /// # Errors
     ///
     /// Returns a `HandleOpenError` if the file cannot be opened.
+    #[cfg(feature = "std")]
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self, HandleOpenError> {
+        let inner = InnerHandle::open(path.as_ref())?;
+        Ok(ReadWriteFileHandle { inner })
+    }
+
+    /// Opens a file in read-write mode with shared access.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the file to open.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `HandleOpenError` if the file cannot be opened.
+    #[cfg(not(feature = "std"))]
     pub fn open(path: &str) -> Result<Self, HandleOpenError> {
         let inner = InnerHandle::open(path)?;
         Ok(ReadWriteFileHandle { inner })
@@ -58,6 +74,32 @@ impl ReadWriteFileHandle {
     /// - The file cannot be created
     /// - Pre-allocation fails
     /// - The path is invalid
+    #[cfg(feature = "std")]
+    pub fn create_preallocated<P: AsRef<std::path::Path>>(
+        path: P,
+        size: i64,
+    ) -> Result<Self, HandleOpenError> {
+        let inner = InnerHandle::create_preallocated(path.as_ref(), size)?;
+        Ok(ReadWriteFileHandle { inner })
+    }
+
+    /// Creates a new file with pre-allocated size.
+    ///
+    /// This creates a new file and pre-allocates the specified amount of space.
+    /// If the file already exists, it will be truncated and pre-allocated to the specified size.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the file should be created
+    /// * `size` - The size to pre-allocate in bytes
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`HandleOpenError`] if:
+    /// - The file cannot be created
+    /// - Pre-allocation fails
+    /// - The path is invalid
+    #[cfg(not(feature = "std"))]
     pub fn create_preallocated(path: &str, size: i64) -> Result<Self, HandleOpenError> {
         let inner = InnerHandle::create_preallocated(path, size)?;
         Ok(ReadWriteFileHandle { inner })
@@ -84,7 +126,7 @@ impl ReadWriteFileHandle {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::{fs::*, io::*};

--- a/src/handles/readwrite/unix.rs
+++ b/src/handles/readwrite/unix.rs
@@ -11,6 +11,16 @@ unsafe impl Sync for InnerHandle {}
 unsafe impl Send for InnerHandle {}
 
 impl InnerHandle {
+    #[cfg(feature = "std")]
+    pub fn open(path: &std::path::Path) -> Result<Self, HandleOpenError> {
+        let path_str = path.to_str().ok_or_else(|| {
+            HandleOpenError::failed_to_open_file_handle_unix(-1, "<invalid_utf8>")
+        })?;
+        let fd = open_with_flags(path_str, O_RDWR)?;
+        Ok(InnerHandle { fd })
+    }
+
+    #[cfg(not(feature = "std"))]
     pub fn open(path: &str) -> Result<Self, HandleOpenError> {
         let fd = open_with_flags(path, O_RDWR)?;
         Ok(InnerHandle { fd })
@@ -21,6 +31,21 @@ impl InnerHandle {
         self.fd
     }
 
+    #[cfg(feature = "std")]
+    pub fn create_preallocated(path: &std::path::Path, size: i64) -> Result<Self, HandleOpenError> {
+        let path_str = path.to_str().ok_or_else(|| {
+            HandleOpenError::failed_to_open_file_handle_unix(-1, "<invalid_utf8>")
+        })?;
+        let fd = open_with_flags(path_str, O_RDWR | O_CREAT)?;
+        if let Err(e) = set_file_size(fd, size) {
+            unsafe { close(fd) };
+            return Err(e);
+        }
+
+        Ok(InnerHandle { fd })
+    }
+
+    #[cfg(not(feature = "std"))]
     pub fn create_preallocated(path: &str, size: i64) -> Result<Self, HandleOpenError> {
         let fd = open_with_flags(path, O_RDWR | O_CREAT)?;
         if let Err(e) = set_file_size(fd, size) {

--- a/src/handles/windows_common.rs
+++ b/src/handles/windows_common.rs
@@ -1,4 +1,5 @@
 use super::HandleOpenError;
+#[cfg(not(feature = "std"))]
 use crate::util::to_wide;
 use core::{ffi::c_void, ptr::*};
 use windows_sys::Win32::{Foundation::*, Storage::FileSystem::*};
@@ -14,6 +15,52 @@ use windows_sys::Win32::{Foundation::*, Storage::FileSystem::*};
 /// # Errors
 ///
 /// Returns a `HandleOpenError` if the file cannot be opened or the path conversion fails.
+#[cfg(feature = "std")]
+pub(crate) fn open_with_access(
+    path: &std::path::Path,
+    access: u32,
+    creation: u32,
+) -> Result<*mut c_void, HandleOpenError> {
+    // Convert Path to wide string directly via OsStr
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+    let wide_path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
+
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            null_mut(),
+            creation,
+            FILE_ATTRIBUTE_NORMAL,
+            null_mut(),
+        )
+    };
+
+    if handle == INVALID_HANDLE_VALUE {
+        let error_code = unsafe { GetLastError() };
+        let path_str = path.to_string_lossy();
+        return Err(HandleOpenError::failed_to_open_file_handle(
+            error_code, &path_str,
+        ));
+    }
+
+    Ok(handle)
+}
+
+/// Opens the file with specified access and shared permissions.
+///
+/// # Arguments
+///
+/// * `path` - The path to the file to open.
+/// * `access` - Desired access rights ([`GENERIC_READ`] or [`GENERIC_READ`] | [`GENERIC_WRITE`])
+/// * `creation` - Creation disposition (e.g., [`CREATE_NEW`], [`OPEN_EXISTING`])
+///
+/// # Errors
+///
+/// Returns a `HandleOpenError` if the file cannot be opened or the path conversion fails.
+#[cfg(not(feature = "std"))]
 pub(crate) fn open_with_access(
     path: &str,
     access: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,10 @@ pub mod mmap;
 pub(crate) mod util;
 
 extern crate alloc;
+
+// Re-export the main types at the crate root for convenience
+pub use handles::{HandleOpenError, ReadOnlyFileHandle, ReadWriteFileHandle};
+#[cfg(feature = "mmap")]
+pub use mmap::{
+    MemoryAdvice, MmapError, OwnedReadOnlyMmap, OwnedReadWriteMmap, ReadOnlyMmap, ReadWriteMmap,
+};

--- a/src/mmap/error.rs
+++ b/src/mmap/error.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::{String, ToString};
+
 /// Represents errors that can occur during memory mapping.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(not(feature = "no-format"), derive(thiserror::Error))]

--- a/src/mmap/readonly/mod.rs
+++ b/src/mmap/readonly/mod.rs
@@ -113,7 +113,7 @@ impl<'a> ReadOnlyMmap<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/mmap/readonly/owned.rs
+++ b/src/mmap/readonly/owned.rs
@@ -89,7 +89,7 @@ impl DerefMut for OwnedReadOnlyMmap {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/mmap/readwrite/mod.rs
+++ b/src/mmap/readwrite/mod.rs
@@ -124,7 +124,7 @@ impl<'a> ReadWriteMmap<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::{

--- a/src/mmap/readwrite/owned.rs
+++ b/src/mmap/readwrite/owned.rs
@@ -88,7 +88,7 @@ impl DerefMut for OwnedReadWriteMmap {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/util/windows.rs
+++ b/src/util/windows.rs
@@ -1,7 +1,5 @@
 use core::mem::zeroed;
-use core::ptr::null_mut;
 use windows_sys::Win32::System::SystemInformation::*;
-use windows_sys::Win32::{Foundation::*, Globalization::*};
 
 /// Converts a `&str` to a wide string (`Box<[u16]>`) for Windows API using [`MultiByteToWideChar`].
 ///
@@ -12,7 +10,11 @@ use windows_sys::Win32::{Foundation::*, Globalization::*};
 /// # Errors
 ///
 /// Returns the Windows error code if the conversion fails.
+#[cfg(not(feature = "std"))]
 pub fn to_wide(s: &str) -> Result<Box<[u16]>, u32> {
+    use core::ptr::null_mut;
+    use windows_sys::Win32::{Foundation::*, Globalization::*};
+
     let c_str = s.as_bytes();
 
     unsafe {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/lightweight-mmap/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced file handle APIs to accept both string and path types depending on standard library availability, improving flexibility for file operations across platforms.
  * Added re-exports of key file handle and memory mapping types at the crate root for easier access.
* **Bug Fixes**
  * Improved error handling for invalid or non-UTF-8 file paths.
* **Chores**
  * Updated several dependencies to their latest versions.
  * Refined test configuration to only run certain tests when the standard library is enabled.
  * Updated GitHub Actions workflow for broader build coverage and clearer labeling.
  * Adjusted development environment settings for Rust code analysis.
  * Improved documentation examples with realistic file names, clearer usage patterns, and added guidance on API differences between std and no_std builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->