### PR TITLE
Improved: no_std compilation/prelude checking

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -243,6 +243,9 @@ let handle4 = ReadWriteFileHandle::create_preallocated("temp_test.txt", 1024).un
 # }
 ```
 
+Existing `no_std` code with `&str` should continue to work, but for wrappers of `&str` 
+you may need to implement `AsRef<std::path::Path>` for your type.
+
 ### Without `std` feature (no_std)
 
 When the `std` feature is disabled, file path parameters only accept `&str`:

--- a/src/handles/error.rs
+++ b/src/handles/error.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 use core::fmt::*;
 

--- a/src/handles/readwrite/mod.rs
+++ b/src/handles/readwrite/mod.rs
@@ -129,7 +129,7 @@ impl ReadWriteFileHandle {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
-    use std::{fs::*, io::*};
+    use std::{fs::*, io::*, string::String, vec::Vec};
     use tempfile::{NamedTempFile, TempDir};
 
     #[test]

--- a/src/handles/windows_common.rs
+++ b/src/handles/windows_common.rs
@@ -24,6 +24,7 @@ pub(crate) fn open_with_access(
     // Convert Path to wide string directly via OsStr
     use std::iter::once;
     use std::os::windows::ffi::OsStrExt;
+    use std::vec::Vec;
     let wide_path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
 
     let handle = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.MD")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 // #[cfg(feature = "c-exports")]
 // pub mod exports;
 

--- a/src/mmap/error.rs
+++ b/src/mmap/error.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 
 /// Represents errors that can occur during memory mapping.

--- a/src/mmap/readonly/mod.rs
+++ b/src/mmap/readonly/mod.rs
@@ -117,6 +117,7 @@ impl<'a> ReadOnlyMmap<'a> {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::vec;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/src/mmap/readwrite/mod.rs
+++ b/src/mmap/readwrite/mod.rs
@@ -130,6 +130,9 @@ mod tests {
     use std::{
         fs::File,
         io::{Read, Write},
+        string::String,
+        vec,
+        vec::Vec,
     };
     use tempfile::NamedTempFile;
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/lightweight-mmap/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal library configuration to enforce `no_std` mode by default, with compatibility for the standard library when enabled.
  * Adjusted imports in test modules to explicitly include required types, ensuring consistent test behavior across environments.
  * Streamlined import statements for string and vector types to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->