### PR TITLE
Migrate macOS Runners to latest images.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,16 +54,16 @@ jobs:
           # aarch64 is disabled; because there is no native runner
 
           # macOS Targets - std features
-          - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
-          - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
-          - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
 
           # macOS Targets - no_std features
-          - { os: macos-13, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "mmap" }
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-pgo: true, use-cross: false, features: "mmap" }
 
-          - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
-          - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
-          - { os: macos-14, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
+          - { os: macos-latest, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap" }
+          - { os: macos-latest, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format" }
+          - { os: macos-latest, target: aarch64-apple-darwin, use-pgo: true, use-cross: false, features: "std mmap no-format trim-file-lengths" }
 
           # Android Targets (Cross-compiled on Ubuntu)
           - { os: ubuntu-latest, target: x86_64-linux-android, use-pgo: false, use-cross: true, features: "std mmap" }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/lightweight-mmap/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated macOS CI runners to newer versions for both Intel and Apple Silicon, maintaining coverage across std/no_std and mmap-only variants.
  - Consolidated macOS build entries to streamline workflows and improve reliability.
  - Android, Linux, and Windows pipelines remain unchanged.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->